### PR TITLE
feat: support modifiers for test method names

### DIFF
--- a/src/main/kotlin/com/github/linuxchina/jetbrains/plugins/vitest/VitestBaseRunLineMarkerProvider.kt
+++ b/src/main/kotlin/com/github/linuxchina/jetbrains/plugins/vitest/VitestBaseRunLineMarkerProvider.kt
@@ -243,7 +243,7 @@ open class VitestBaseRunLineMarkerProvider : RunLineMarkerProvider() {
 
     fun isVitestTestMethod(jsCallExpression: JSCallExpression): Boolean {
         val firstChild = jsCallExpression.firstChild
-        if (firstChild != null && firstChild is JSReferenceExpression && vitestTestMethodNames.contains(firstChild.text)) {
+        if (firstChild != null && firstChild is JSReferenceExpression && vitestTestMethodNames.contains(firstChild.text.split(".")[0])) {
             val project = jsCallExpression.project
             if (project.getService(VitestService::class.java).globalServiceEnabled) {
                 return true

--- a/src/main/kotlin/com/github/linuxchina/jetbrains/plugins/vitest/VitestRunLineMarkerContributor.kt
+++ b/src/main/kotlin/com/github/linuxchina/jetbrains/plugins/vitest/VitestRunLineMarkerContributor.kt
@@ -19,7 +19,7 @@ class VitestRunLineMarkerContributor : RunLineMarkerContributor() {
     override fun getInfo(element: PsiElement): Info? {
         if (element is JSCallExpression) {
             val firstChild = element.firstChild
-            if (firstChild != null && firstChild is JSReferenceExpression && VitestBaseRunLineMarkerProvider.vitestTestMethodNames.contains(firstChild.text)) {
+            if (firstChild != null && firstChild is JSReferenceExpression && VitestBaseRunLineMarkerProvider.vitestTestMethodNames.contains(firstChild.text.split(".")[0])) {
                 val watchAction = object : AnAction("Watch", "Run Vitest with watch mode", watchIcon) {
                     override fun actionPerformed(e: AnActionEvent) {
                         VitestBaseRunLineMarkerProvider.runSingleVitest(element, true)


### PR DESCRIPTION
Hi @linux-china ,

first a big thank you for building this. The plugin has been really helpful so far!

It would be super cool, if the Plugin would recognise `describe.concurrent` and similar test method names with modifiers.